### PR TITLE
feat: adds ability to get ReturnValue attributes from an update_document call

### DIFF
--- a/awspytools/DynamoDBDataStore.py
+++ b/awspytools/DynamoDBDataStore.py
@@ -170,7 +170,7 @@ class DynamoDBDataStore(object):
         paginator = self.client.get_paginator(paginator_type)
         return paginator.paginate(**parameters)
 
-    def update_document(self, index=None, parameters=None, return_attributes=False, return_index=False):
+    def update_document(self, index=None, parameters=None, return_value: ReturnValues=ReturnValues.NONE, return_index=False):
 
         if parameters is None:
             parameters = {}
@@ -189,8 +189,8 @@ class DynamoDBDataStore(object):
             'Key': key,
             **parameters
         }
-        if return_attributes:
-            params["ReturnValues"] = return_attributes.value
+        if return_value != ReturnValues.NONE:
+            params["ReturnValues"] = return_value.value
 
         try:
             item = self.client.update_item(**params).get("Attributes")

--- a/awspytools/__init__.py
+++ b/awspytools/__init__.py
@@ -1,1 +1,1 @@
-from .DynamoDBDataStore import DynamoDBDataStore
+from .DynamoDBDataStore import DynamoDBDataStore, ReturnValues

--- a/tests/test_dynamodb_update.py
+++ b/tests/test_dynamodb_update.py
@@ -23,7 +23,7 @@ def test_all_new():
     new_document = store.update_document(
         index=(PK, SK),
         parameters=UPDATE_PARAMS,
-        return_attributes=ReturnValues.ALL_NEW,
+        return_value=ReturnValues.ALL_NEW,
     )
     assert new_document == {ATTR_1: NEW, ATTR_2: OLD}
 
@@ -33,7 +33,7 @@ def test_updated_new():
     new_document = store.update_document(
         index=(PK, SK),
         parameters=UPDATE_PARAMS,
-        return_attributes=ReturnValues.UPDATED_NEW,
+        return_value=ReturnValues.UPDATED_NEW,
     )
     assert new_document == {ATTR_1: NEW}
 
@@ -43,7 +43,7 @@ def test_all_old():
     new_document = store.update_document(
         index=(PK, SK),
         parameters=UPDATE_PARAMS,
-        return_attributes=ReturnValues.ALL_OLD,
+        return_value=ReturnValues.ALL_OLD,
     )
     assert new_document == DOCUMENT
 
@@ -53,7 +53,7 @@ def test_updated_old():
     new_document = store.update_document(
         index=(PK, SK),
         parameters=UPDATE_PARAMS,
-        return_attributes=ReturnValues.UPDATED_OLD,
+        return_value=ReturnValues.UPDATED_OLD,
     )
     assert new_document == {ATTR_1: OLD}
 
@@ -63,7 +63,7 @@ def test_none():
     new_document = store.update_document(
         index=(PK, SK),
         parameters=UPDATE_PARAMS,
-        return_attributes=ReturnValues.NONE,
+        return_value=ReturnValues.NONE,
     )
     assert new_document is None
 
@@ -73,7 +73,7 @@ def test_return_index():
     new_document = store.update_document(
         index=(PK, SK),
         parameters=UPDATE_PARAMS,
-        return_attributes=ReturnValues.ALL_OLD,
+        return_value=ReturnValues.ALL_OLD,
         return_index=True,
     )
     assert new_document == {**DOCUMENT, PK: PK, SK: SK}

--- a/tests/test_dynamodb_update.py
+++ b/tests/test_dynamodb_update.py
@@ -1,0 +1,79 @@
+import os
+from awspytools import DynamoDBDataStore, ReturnValues
+
+store = DynamoDBDataStore(os.environ["CORE_TABLE_NAME"])
+
+OLD = "OLD"
+NEW = "NEW"
+ATTR_1 = "ATTR_1"
+ATTR_2 = "ATTR_2"
+PK = "PK"
+SK = "SK"
+DOCUMENT = {ATTR_1: OLD, ATTR_2: OLD}
+UPDATE_PARAMS = {
+    "UpdateExpression": f"SET {ATTR_1} = :new",
+    "ExpressionAttributeValues": {
+        ":new": {"S": NEW},
+    },
+}
+
+
+def test_all_new():
+    store.save_document(document=DOCUMENT, index=(PK, SK))
+    new_document = store.update_document(
+        index=(PK, SK),
+        parameters=UPDATE_PARAMS,
+        return_attributes=ReturnValues.ALL_NEW,
+    )
+    assert new_document == {ATTR_1: NEW, ATTR_2: OLD}
+
+
+def test_updated_new():
+    store.save_document(document=DOCUMENT, index=(PK, SK))
+    new_document = store.update_document(
+        index=(PK, SK),
+        parameters=UPDATE_PARAMS,
+        return_attributes=ReturnValues.UPDATED_NEW,
+    )
+    assert new_document == {ATTR_1: NEW}
+
+
+def test_all_old():
+    store.save_document(document=DOCUMENT, index=(PK, SK))
+    new_document = store.update_document(
+        index=(PK, SK),
+        parameters=UPDATE_PARAMS,
+        return_attributes=ReturnValues.ALL_OLD,
+    )
+    assert new_document == DOCUMENT
+
+
+def test_updated_old():
+    store.save_document(document=DOCUMENT, index=(PK, SK))
+    new_document = store.update_document(
+        index=(PK, SK),
+        parameters=UPDATE_PARAMS,
+        return_attributes=ReturnValues.UPDATED_OLD,
+    )
+    assert new_document == {ATTR_1: OLD}
+
+
+def test_none():
+    store.save_document(document=DOCUMENT, index=(PK, SK))
+    new_document = store.update_document(
+        index=(PK, SK),
+        parameters=UPDATE_PARAMS,
+        return_attributes=ReturnValues.NONE,
+    )
+    assert new_document is None
+
+
+def test_return_index():
+    store.save_document(document=DOCUMENT, index=(PK, SK))
+    new_document = store.update_document(
+        index=(PK, SK),
+        parameters=UPDATE_PARAMS,
+        return_attributes=ReturnValues.ALL_OLD,
+        return_index=True,
+    )
+    assert new_document == {**DOCUMENT, PK: PK, SK: SK}


### PR DESCRIPTION
A call to boto3's update_item method can include a flag to get ReturnValues passed back. This could be one of 'NONE', 'ALL_OLD', 'UPDATED_OLD', 'ALL_NEW' or 'UPDATED_NEW'.

This PR exposes the functionality and returns the modified/previous deserialized attributes, if requested. 

Based of #4 